### PR TITLE
Spec requirements admission controller and tests

### DIFF
--- a/cmd/kube-apiserver/app/plugins.go
+++ b/cmd/kube-apiserver/app/plugins.go
@@ -44,5 +44,6 @@ import (
 	_ "k8s.io/kubernetes/plugin/pkg/admission/security/podsecuritypolicy"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
+	_ "k8s.io/kubernetes/plugin/pkg/admission/specrequirements/scdeny"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/storageclass/default"
 )

--- a/plugin/pkg/admission/specrequirements/admission.go
+++ b/plugin/pkg/admission/specrequirements/admission.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The SpecRequirements package contains an admission controller that ensures that resources created or updated by
+// human cluster users meet two criteria:
+// - they have a contact label
+// - if pods will be created, they have resource requirements specified
+// Resources that do not meet those criteria will not be created/updated
+// In addition, the admission controller propagates an existing contact label to pods, if the main resource being
+// handled is not a pod but contains pods (e.g. deployments or jobs)
+package specrequirements
+
+import (
+	"io"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func init() {
+	admission.RegisterPlugin("SpecRequirements", func(config io.Reader) (admission.Interface, error) {
+		return NewSpecRequirements(), nil
+	})
+}
+
+type specRequirements struct {
+	*admission.Handler
+}
+
+//Admit returns nil if the resource meets the criteria for creation/updating, and an error otherwise.
+func (a *specRequirements) Admit(attributes admission.Attributes) (err error) {
+	// We only want to filter resources created by human cluster users.
+	if !strings.Contains(attributes.GetUserInfo().GetName(), "admin") {
+		return nil
+	}
+
+	// Check for a contact label
+	contact := HasContact(attributes.GetObject())
+
+	// Stop the resource update/creation if there is not contact label
+	if contact == "" {
+		mess := fmt.Sprintf("Cannot %s this resource. It does not have a valid contact label. Please add one " +
+			"and try again.", strings.ToLower(string(attributes.GetOperation())))
+		return admission.NewForbidden(attributes, errors.New(mess))
+	}
+
+	// Get the pod template spec, if the resource has one
+	// We need this to propagate the contact label, and to check whether resource requests have been specified.
+	template, hasTemplate := GetPodTemplate(attributes.GetObject())
+
+	if hasTemplate {
+		PropagateLabel(template, contact)
+	}
+
+	// Only resources with pod specs in them need to specify resource requirements.
+	if attributes.GetKind().Kind != "Pod" && !hasTemplate {
+		return nil
+	}
+
+	// The resource is either a pod, or a resource that contains a pod spec.
+	// Find out whether resource requests are specified.
+	requestsPresent := true
+	var containers []api.Container
+	if attributes.GetKind().Kind == "Pod" {
+		podSpec := attributes.GetObject().(*api.Pod).Spec
+		containers = append(podSpec.InitContainers, podSpec.Containers...)
+		requestsPresent = HasResourceRequests(containers)
+	} else if hasTemplate {
+		containers = append(template.Spec.InitContainers, template.Spec.Containers...)
+		requestsPresent = HasResourceRequests(containers)
+	}
+
+	// If there is at least one CPU or memory request missing in a container, stop the resource from getting
+	// updated or created.
+	if !requestsPresent {
+		mess := fmt.Sprintf("Cannot %s this resource. Some containers do not have resource requests " +
+			"specified. Please add resource requests to every container in the pod spec and try again.",
+			strings.ToLower(string(attributes.GetOperation())))
+		return admission.NewForbidden(attributes, errors.New(mess))
+	}
+
+	return nil
+}
+
+//Returns true if the given object has a contact label - not case-sensitive - in its metadata, false otherwise.
+func HasContact(resource runtime.Object) string {
+	accessor := meta.NewAccessor()
+	labels, _ := accessor.Labels(resource)
+	for key, value := range labels {
+		if strings.ToLower(key) == "contact" {
+			return value
+		}
+	}
+	return ""
+}
+
+
+//This adds a contact label to the given pod template spec. This is used in the case of resources that contain pods
+//but are not pods themselves (e.g. deployments).
+func PropagateLabel(template *api.PodTemplateSpec, contact string) {
+	if template.Labels == nil {
+		template.Labels = make(map[string]string)
+	}
+	template.Labels["contact"] = contact
+}
+
+//Returns true if all the given containers have memory and cpu resource requests set, false otherwise.
+func HasResourceRequests(containers []api.Container) bool {
+	requestsPresent := true
+
+	//containers := append(template.Spec.Containers, template.Spec.InitContainers...)
+	for _, container := range containers{
+		requests := container.Resources.Requests
+		_, mem := requests[api.ResourceMemory]
+		_, cpu := requests[api.ResourceCPU]
+		requestsPresent = requestsPresent && mem && cpu
+	}
+
+	return requestsPresent
+
+}
+
+//This returns the PodTemplateSpec part of the given resource and true if the resource has a PodTemplateSpec part.
+//It returns an empty PodTemplateSpec and false otherwise.
+func GetPodTemplate(resource runtime.Object) (*api.PodTemplateSpec, bool) {
+
+	emptyTemplate := api.PodTemplateSpec{}
+
+	possibleSpec := reflect.ValueOf(resource).Elem().FieldByName("Spec")
+	if !possibleSpec.IsValid() {
+		return &emptyTemplate, false
+	}
+
+	spec := possibleSpec.Addr().Interface()
+	possibleTemplate := reflect.ValueOf(spec).Elem().FieldByName("Template")
+	if !possibleTemplate.IsValid() {
+		return &emptyTemplate, false
+	}
+
+	podTemplate := possibleTemplate.Addr().Interface().(*api.PodTemplateSpec)
+	return podTemplate, true
+
+}
+
+func NewSpecRequirements() admission.Interface {
+	return &specRequirements{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+	}
+}
+

--- a/plugin/pkg/admission/specrequirements/admission.go
+++ b/plugin/pkg/admission/specrequirements/admission.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2015 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 // The SpecRequirements package contains an admission controller that ensures that resources created or updated by
 // human cluster users meet two criteria:
 // - they have a contact label
@@ -101,7 +85,7 @@ func (a *specRequirements) Admit(attributes admission.Attributes) (err error) {
 	return nil
 }
 
-//Returns true if the given object has a contact label - not case-sensitive - in its metadata, false otherwise.
+//Returns the value of the contact label if the resource has a contact label, the empty string otherwise.
 func HasContact(resource runtime.Object) string {
 	accessor := meta.NewAccessor()
 	labels, _ := accessor.Labels(resource)
@@ -127,7 +111,6 @@ func PropagateLabel(template *api.PodTemplateSpec, contact string) {
 func HasResourceRequests(containers []api.Container) bool {
 	requestsPresent := true
 
-	//containers := append(template.Spec.Containers, template.Spec.InitContainers...)
 	for _, container := range containers{
 		requests := container.Resources.Requests
 		_, mem := requests[api.ResourceMemory]

--- a/plugin/pkg/admission/specrequirements/admission_test.go
+++ b/plugin/pkg/admission/specrequirements/admission_test.go
@@ -1,0 +1,371 @@
+package specrequirements
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/batch"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+)
+
+func TestHasContact(t *testing.T) {
+	labelsWithContact := make(map[string]string)
+	expectedContact := "hodor"
+	labelsWithContact["contact"] = expectedContact
+	labelsWithContact["app"] = "doorholding"
+	podWithContact := api.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "podWithContact", Namespace: "infrastructure", Labels: labelsWithContact},
+	}
+	resultingContact := HasContact(&podWithContact)
+	LabelHelper(expectedContact, resultingContact, t)
+
+	expectedContact = ""
+	jobWithoutContact := batch.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "jobWithOutContact", Namespace: "infrastructure"},
+	}
+	resultingContact = HasContact(&jobWithoutContact)
+	LabelHelper(expectedContact, resultingContact, t)
+}
+
+func TestPropagateLabel(t *testing.T) {
+
+	// no labels present in template spec
+	podTemplate := api.PodTemplateSpec{
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{Name: "container1", Image: "image"},
+				{Name: "container2", Image: "anotherimage"},
+			},
+		},
+	}
+	_, ok := podTemplate.Labels["contact"]
+	if ok {
+		t.Errorf("Contact label was unexpectedly found in pod spec.")
+	}
+	expected := "hodor"
+	PropagateLabel(&podTemplate, expected)
+	actual, err := podTemplate.Labels["contact"]
+	if !err {
+		t.Errorf("Contact label was not found in pod spec.")
+	}
+	LabelHelper(expected, actual, t)
+
+	// some labels present in template spec - the spec after calling PropagateLabels should contain the original labels
+	// and the new contact label
+	labels := make(map[string]string)
+	labels["app"] = "train"
+	labels["project"] = "infra"
+	podTemplateWithSomeLabels := api.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Labels: labels},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{Name: "container1", Image: "image"},
+				{Name: "container2", Image: "anotherimage"},
+			},
+		},
+	}
+	_, ok = podTemplateWithSomeLabels.Labels["contact"]
+	if ok {
+		t.Errorf("Contact label was unexpectedly found in pod spec.")
+	}
+	expected = "hodor"
+	PropagateLabel(&podTemplateWithSomeLabels, expected)
+	actual, err = podTemplateWithSomeLabels.Labels["contact"]
+	if !err {
+		t.Errorf("Contact label was not found in pod spec.")
+	}
+	LabelHelper(expected, actual, t)
+	actual, err = podTemplateWithSomeLabels.Labels["app"]
+	if !err {
+		t.Errorf("app label was not found in pod spec.")
+	}
+	LabelHelper("train", actual, t)
+	actual, err = podTemplateWithSomeLabels.Labels["project"]
+	if !err {
+		t.Errorf("project label was not found in pod spec.")
+	}
+	LabelHelper("infra", actual, t)
+}
+
+func LabelHelper(expected string, actual string, t *testing.T) {
+	if expected != actual {
+		t.Errorf("Label value should have been %s, but was %s.", expected, actual)
+	}
+}
+
+func TestHasResourceRequests(t *testing.T) {
+
+	// Values for both CPU and memory included
+	bothResourcesMap := make(map[api.ResourceName]resource.Quantity)
+	bothResourcesMap[api.ResourceCPU] = *resource.NewQuantity(100, resource.DecimalSI)
+	bothResourcesMap[api.ResourceMemory] = *resource.NewQuantity(200, resource.DecimalSI)
+	bothResourcesRequest := api.ResourceRequirements{Requests: bothResourcesMap}
+
+	// Request for CPU only
+	cpuOnlyMap := make(map[api.ResourceName]resource.Quantity)
+	cpuOnlyMap[api.ResourceCPU] = *resource.NewQuantity(100, resource.DecimalSI)
+	cpuOnlyRequest := api.ResourceRequirements{Requests: cpuOnlyMap}
+
+	// Request for memory only
+	memoryOnlyMap := make(map[api.ResourceName]resource.Quantity)
+	memoryOnlyMap[api.ResourceMemory] = *resource.NewQuantity(200, resource.DecimalSI)
+	memoryOnlyRequest := api.ResourceRequirements{Requests: memoryOnlyMap}
+
+	// All containers have both CPU and memory requests. Should return true.
+	twoContainersWithRequests := []api.Container{
+		{Name: "first", Image: "image1", Resources: bothResourcesRequest},
+		{Name: "second", Image: "image2", Resources: bothResourcesRequest},
+	}
+
+	// No containers have any requests. Should return false.
+	noContainersHaveRequests := []api.Container{
+		{Name: "first", Image: "image1"},
+		{Name: "second", Image: "image2"},
+	}
+
+	// One container has both CPU and memory requests, the other has no requests. Should return false.
+	mixture := []api.Container{
+		{Name: "first", Image: "image1", Resources: bothResourcesRequest},
+		{Name: "second", Image: "image2"},
+	}
+
+	// One container hasn't specified a memory request. Should return false.
+	memoryMissing := []api.Container{
+		{Name: "first", Image: "image1", Resources: cpuOnlyRequest},
+		{Name: "second", Image: "image2"},
+	}
+
+	// One container hasn't specified a CPU request. Should return false.
+	cpuMissing := []api.Container{
+		{Name: "first", Image: "image1"},
+		{Name: "second", Image: "image2", Resources: memoryOnlyRequest},
+	}
+
+	result := HasResourceRequests(twoContainersWithRequests)
+	resourceHelper(true, result, t)
+	result = HasResourceRequests(noContainersHaveRequests)
+	resourceHelper(false, result, t)
+	result = HasResourceRequests(mixture)
+	resourceHelper(false, result, t)
+	result = HasResourceRequests(memoryMissing)
+	resourceHelper(false, result, t)
+	result = HasResourceRequests(cpuMissing)
+	resourceHelper(false, result, t)
+}
+
+func resourceHelper(expected bool, actual bool, t *testing.T) {
+	if expected != actual {
+		t.Errorf("Unexpected result for resource check. Was %t instead of %t.", actual, expected)
+	}
+}
+
+func TestGetPodTemplate(t *testing.T) {
+
+	// Test for Jobs
+	jobPodTemplateSpec := api.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Name: "jobpod"},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{Name: "jobcontainer1", Image: "jobimage"},
+			},
+		},
+	}
+	job := batch.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "job"},
+		Spec: batch.JobSpec{
+			Template: jobPodTemplateSpec,
+		},
+	}
+	template, hasTemplate := GetPodTemplate(&job)
+	templateGetterHelper(&jobPodTemplateSpec, true, template, hasTemplate, t)
+
+	// Test for Deployments
+	deploymentPodTemplateSpec := api.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Name: "deploymentpod"},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{Name: "deploymentcontainer1", Image: "deploymentimage"},
+			},
+		},
+	}
+	deployment := extensions.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "deployment"},
+		Spec: extensions.DeploymentSpec{
+			Template: deploymentPodTemplateSpec,
+		},
+	}
+	template, hasTemplate = GetPodTemplate(&deployment)
+	templateGetterHelper(&deploymentPodTemplateSpec, true, template, hasTemplate, t)
+
+	// Testing resources that do not have PodTemplateSpecs
+	// We expect an empty pod template spec for these
+	emptyTemplate := &api.PodTemplateSpec{}
+
+	// Test for Pods - Pods contain PodSpecs, there is no PodTemplateSpec.
+	pod := api.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{Name: "deploymentcontainer1", Image: "deploymentimage"},
+			},
+		},
+	}
+	template, hasTemplate = GetPodTemplate(&pod)
+	templateGetterHelper(emptyTemplate, false, template, hasTemplate, t)
+
+	// Test for Services
+	selectors := make(map[string]string)
+	selectors["app"] = "search"
+	selectors["project"] = "infra"
+	service := api.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "service"},
+		Spec: api.ServiceSpec {
+			Selector: selectors,
+		},
+	}
+	template, hasTemplate = GetPodTemplate(&service)
+	templateGetterHelper(emptyTemplate, false, template, hasTemplate, t)
+
+
+}
+
+func templateGetterHelper(expectedTemplate *api.PodTemplateSpec, expectedPresence bool, actualTemplate *api.PodTemplateSpec, actualPresence bool, t *testing.T){
+	if expectedPresence != actualPresence || !reflect.DeepEqual(expectedTemplate, actualTemplate) {
+		t.Errorf("Unexpected results when attempting to get pod spec template from resource.\n %+v,\n %t,\n %+v,\n %t", expectedTemplate, expectedPresence, actualTemplate, actualPresence)
+	}
+}
+
+ //TestAdmission verifies all create requests for pods result in every container's image pull policy
+ //set to Always
+func TestAdmission(t *testing.T) {
+
+	handler := &specRequirements{}
+
+	// Testing resources created by human.
+	humanUser := user.DefaultInfo{Name: "admin"}
+
+	// No contact, contains no pods. Should not be admitted.
+	selectors := make(map[string]string)
+	selectors["app"] = "search"
+	selectors["project"] = "infra"
+	noContactService := api.Service {
+		ObjectMeta: metav1.ObjectMeta{Name: "service"},
+		Spec: api.ServiceSpec {
+			Selector: selectors,
+		},
+	}
+	input := admission.NewAttributesRecord(&noContactService, nil, api.Kind("Service").WithVersion("version"), "", "", api.Resource("services").WithVersion("version"), "", admission.Create, &humanUser)
+	err := handler.Admit(input)
+	if err == nil {
+		t.Errorf("A service without a contact label was admitted.")
+	}
+
+	// Contains contact but not resources. Should not be admitted.
+	labelsWithContact := make(map[string]string)
+	labelsWithContact["contact"] = "hodor"
+	deploymentWithContactNoResources := extensions.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "deployment", Labels: labelsWithContact},
+		Spec: extensions.DeploymentSpec{
+			Template: api.PodTemplateSpec{
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{Name: "deploymentcontainer1", Image: "deploymentimage"},
+					},
+				},
+			},
+		},
+	}
+
+	input = admission.NewAttributesRecord(&deploymentWithContactNoResources, nil, api.Kind("Job").WithVersion("version"), "", "", api.Resource("jobs").WithVersion("version"), "", admission.Update, &humanUser)
+	err = handler.Admit(input)
+	if err == nil {
+		t.Errorf("Deployment with contact label but no resources was admitted.")
+	}
+
+	// Contains contact and resources. Should be admitted.
+	otherLabels := make(map[string]string)
+	otherLabels["app"] = "study"
+	otherLabels["project"] = "infra"
+	bothResourcesMap := make(map[api.ResourceName]resource.Quantity)
+	bothResourcesMap[api.ResourceCPU] = *resource.NewQuantity(100, resource.DecimalSI)
+	bothResourcesMap[api.ResourceMemory] = *resource.NewQuantity(200, resource.DecimalSI)
+	bothResourcesRequest := api.ResourceRequirements{Requests: bothResourcesMap}
+	jobWithContactAndResources := batch.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "job", Labels: labelsWithContact},
+		Spec: batch.JobSpec{
+			Template: api.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: otherLabels},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{Name: "jobcontainer1", Image: "jobimage", Resources: bothResourcesRequest},
+					},
+				},
+			},
+		},
+	}
+
+	input = admission.NewAttributesRecord(&jobWithContactAndResources, nil, api.Kind("Job").WithVersion("version"), "", "", api.Resource("jobs").WithVersion("version"), "", admission.Create, &humanUser)
+    err = handler.Admit(input)
+	if err != nil {
+		t.Errorf("Job with both contact label and resource requests should have been admitted, but wasn't.")
+	}
+	// Verify that other pod labels have not been overwritten, and pod has contact label too now
+	LabelHelper("study", jobWithContactAndResources.Spec.Template.Labels["app"], t)
+	LabelHelper("infra", jobWithContactAndResources.Spec.Template.Labels["project"], t)
+	LabelHelper("hodor", jobWithContactAndResources.Spec.Template.Labels["contact"], t)
+
+	// Make sure that nothing goes wrong when the pod template spec doesn't already have at least one label.
+	jobWithResourcesAndOnlyContactLabel := batch.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "job2", Labels: labelsWithContact},
+		Spec: batch.JobSpec{
+			Template: api.PodTemplateSpec{
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{Name: "jobcontainer2", Image: "jobimage2", Resources: bothResourcesRequest},
+					},
+				},
+			},
+		},
+	}
+
+	input = admission.NewAttributesRecord(&jobWithResourcesAndOnlyContactLabel, nil, api.Kind("Job").WithVersion("version"), "", "", api.Resource("jobs").WithVersion("version"), "", admission.Create, &humanUser)
+	err = handler.Admit(input)
+	if err != nil {
+		t.Errorf("Job with both contact label and resource requests should have been admitted, but wasn't.")
+	}
+	// Verify that the pod has a contact label too now
+	LabelHelper("hodor", jobWithResourcesAndOnlyContactLabel.Spec.Template.Labels["contact"], t)
+
+	// ConfigMaps only need to have a contact label, as they do not require pod resources
+	cmMap := make(map[string]string)
+	cmMap["key1"] = "value1"
+	cmMap["key2"] = "value2"
+	configMap := api.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "configmap", Labels: labelsWithContact},
+		Data: cmMap,
+	}
+	input = admission.NewAttributesRecord(&configMap, nil, api.Kind("Job").WithVersion("version"), "", "", api.Resource("jobs").WithVersion("version"), "", admission.Update, &humanUser)
+	err = handler.Admit(input)
+	if err != nil {
+		t.Errorf("ConfigMap with contact label should have been admitted, but wasn't.")
+	}
+
+	// Testing admission when the humanUser is not human (i.e. Kubernetes)
+	// Service with no contact label
+	kubeUser := user.DefaultInfo{Name: "kubelet"}
+	input = admission.NewAttributesRecord(&noContactService, nil, api.Kind("Service").WithVersion("version"), "", "", api.Resource("services").WithVersion("version"), "", admission.Create, &kubeUser)
+	if err != nil {
+		t.Errorf("The kubelet user should have been able to create a service without a contact label, but was unable to.")
+	}
+
+	// Deployment with contact label but no resource requests
+	input = admission.NewAttributesRecord(&deploymentWithContactNoResources, nil, api.Kind("Job").WithVersion("version"), "", "", api.Resource("jobs").WithVersion("version"), "", admission.Update, &kubeUser)
+	if err != nil {
+		t.Errorf("The kubelet user should have been able to update a deployment with no resource requests, but was unable to.")
+	}
+}


### PR DESCRIPTION
Admission controller that:
- Does not admit resources created/updated by cluster users that do not have contact labels
- Does not admit resources created/updated by cluster users that do not have resource requests (where applicable)
- Adds contact labels present in resources like deployments and jobs to the pod specs they contain.

Unit tests for the admission controller are included. 